### PR TITLE
fix(phase/variable_types_match): soft fail with Logger.warn

### DIFF
--- a/test/absinthe/integration/execution/input_object_test.exs
+++ b/test/absinthe/integration/execution/input_object_test.exs
@@ -35,7 +35,7 @@ defmodule Elixir.Absinthe.Integration.Execution.InputObjectTest do
                 %{
                   locations: [%{column: 33, line: 2}],
                   message:
-                    "Variable `$input` of type `Boolean` found as input to argument of type `InputThing!`."
+                    "Variable `$input` of type `Boolean` found as input to argument of type `InputThing`."
                 }
               ]
             }} ==

--- a/test/absinthe/phase/document/validation/variables_of_correct_type_test.exs
+++ b/test/absinthe/phase/document/validation/variables_of_correct_type_test.exs
@@ -22,7 +22,7 @@ defmodule Absinthe.Phase.Document.Validation.VariablesOfCorrectTypeTest do
         variables: %{"intArg" => 5}
       )
 
-    expected_error_msg = error_message("test", "intArg", "Int!", "String")
+    expected_error_msg = error_message("test", "intArg", "Int", "String")
     assert expected_error_msg in (errors |> Enum.map(& &1.message))
   end
 
@@ -40,8 +40,7 @@ defmodule Absinthe.Phase.Document.Validation.VariablesOfCorrectTypeTest do
         variables: %{"intArg" => 5}
       )
 
-    expected_error_msg = error_message("test", "intArg", "DoesNotExist!", "String")
-
+    expected_error_msg = "Argument \"stringArg\" has invalid value $intArg."
     assert expected_error_msg in (errors |> Enum.map(& &1.message))
   end
 
@@ -85,6 +84,10 @@ defmodule Absinthe.Phase.Document.Validation.VariablesOfCorrectTypeTest do
     assert expected_error_msg in (errors |> Enum.map(& &1.message))
   end
 
+  # This is one of the cases that the breaking change fixes (and correctly
+  # validates). Re-enable this test once we use the latest version of
+  # Absinthe.Phase.Document.Arguments.VariableTypesMatch
+  @tag :skip
   test "non null types of variables match non null types of arguments" do
     {:ok, %{errors: errors}} =
       Absinthe.run(


### PR DESCRIPTION
Patches breaking change introduced in 1.7 since type mismatches throws errors beginning in 1.7. This patch does a soft fail (through Logger.warn) for newer validation logic while preserving the old validation logic.

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
